### PR TITLE
Renamed issue_count_by_group to result_count_by_group (RedMine 3.4)

### DIFF
--- a/app/models/custom_report_series.rb
+++ b/app/models/custom_report_series.rb
@@ -28,7 +28,7 @@ class CustomReportSeries < ActiveRecord::Base
 
   def data_hash
     true
-    @data_hash ||= (query.issue_count_by_group || {})
+    @data_hash ||= (query.result_count_by_group || {})
   end
 
   def flt=(*args)


### PR DESCRIPTION
Renamed issue_count_by_group to result_count_by_group for Redmine 3.4 compatibility. Prior to Redmine 3.4, there were two versions of the same method. issue_count_by_group and result_count_by_group. As of Redmine 3.4 there is only one (result_count_by_group). Therefore, this change will allow the plugin to work in 3.4 while also maintaining compatibility with previous releases. 

Resolves Issue #38 